### PR TITLE
Fix bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,10 @@ const authorResolvers = {
 
 const extendResolvers = {
   Book: {
-    author: () => ({})
+    author: {
+      fragment: '... on Book { id }',
+      resolve: () => ({})
+    },
   },
 }
 


### PR DESCRIPTION
The problem is you can't extend on a parent without asking for a field on the original. Additionally, you wouldn't WANT to. In your master branch, you have

```js
author: book => {
  console.log('resolving book.author for', book);
  return authors.find(author => author.books.includes(book.id));
}
```

but there's no way for graphql-tools to know that you need to fetch the `id` field, so `book.id` should never exist without this change.